### PR TITLE
fix build breakage on 64 bit systems

### DIFF
--- a/src/handle.cc
+++ b/src/handle.cc
@@ -222,7 +222,7 @@ namespace yajljs
         return 1;
     }
 
-    int OnNumber( void *ctx, const char *numberVal, unsigned int numberLen )
+    int OnNumber( void *ctx, const char *numberVal, size_t numberLen )
     {
         INIT_CB( ctx );
 
@@ -231,7 +231,7 @@ namespace yajljs
         return 1;
     }
 
-    int OnString( void *ctx, const unsigned char *stringVal, unsigned int stringLen )
+    int OnString( void *ctx, const unsigned char *stringVal, size_t stringLen )
     {
         INIT_CB( ctx );
         Local<Value> args[1] = { String::New( (char *)stringVal, stringLen ) };
@@ -246,7 +246,7 @@ namespace yajljs
         return 1;
     }
 
-    int OnMapKey( void *ctx, const unsigned char *key, unsigned int stringLen )
+    int OnMapKey( void *ctx, const unsigned char *key, size_t stringLen )
     {
         INIT_CB( ctx );
         Local<Value> args[1] = { String::New( (char *)key, stringLen ) };

--- a/src/handle.h
+++ b/src/handle.h
@@ -64,10 +64,10 @@ namespace yajljs
     int OnBoolean( void *ctx, int b );
     int OnInteger( void *ctx, long long b );
     int OnDouble( void *ctx, double b );
-    int OnNumber( void *ctx, const char *numberVal, unsigned int numberLen );
-    int OnString( void *ctx, const unsigned char *stringVal, unsigned int stringLen );
+    int OnNumber( void *ctx, const char *numberVal, size_t numberLen );
+    int OnString( void *ctx, const unsigned char *stringVal, size_t stringLen );
     int OnStartMap( void *ctx );
-    int OnMapKey( void *ctx, const unsigned char *key, unsigned int stringLen );
+    int OnMapKey( void *ctx, const unsigned char *key, size_t stringLen );
     int OnEndMap( void *ctx );
     int OnStartArray( void *ctx );
     int OnEndArray( void *ctx );


### PR DESCRIPTION
move to size_t for callbacks because sizeof(size_t) != sizeof(unsigned int) on 64 bit architectures
